### PR TITLE
Change table names to match conventions + fix cache

### DIFF
--- a/messages/database.py
+++ b/messages/database.py
@@ -32,7 +32,7 @@ class UserChannelConfig(database.base):
         ignored_members: IDs of users that are ignored when ranking.
     """
 
-    __tablename__ = "user_channels_config"
+    __tablename__ = "boards_messages_config"
 
     guild_id = Column(BigInteger, primary_key=True, autoincrement=False)
     ignored_channels = Column(ARRAY(BigInteger))
@@ -135,7 +135,7 @@ class UserChannel(database.base):
         last_msg_at: When the last message was sent.
     """
 
-    __tablename__ = "user_channels"
+    __tablename__ = "boards_messages_userchannels"
 
     idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)

--- a/messages/module.py
+++ b/messages/module.py
@@ -99,7 +99,7 @@ class Messages(commands.Cog):
 
         if not self.negative_cache.empty:
             if channel is None:
-                df = self.negative_cache
+                df2 = self.negative_cache
                 self.negative_cache = pd.DataFrame(df_columns)
             else:
                 df2 = pd.DataFrame(columns=self.negative_cache.columns)


### PR DESCRIPTION
Renamed tables to match conventions used in whole pumpkin-py project.

I've also included SQL script to fix already existing tables.

```SQL
ALTER TABLE user_channels_config RENAME TO boards_messages_config;

ALTER TABLE user_channels RENAME TO boards_messages_userchannels;

ALTER SEQUENCE user_channels_idx_seq RENAME TO boards_messages_userchannels_idx_seq;
```